### PR TITLE
Adding a debug log for when boot's completed.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -7,6 +7,8 @@ function run (callbacks, callback) {
     var next = remaining.shift()
 
     if (!next) {
+        debug('Boot completed.')
+
         return callback()
     }
 


### PR DESCRIPTION
Simple, but just helps to ascertain whether or not `microboot`'s run its course or not.
